### PR TITLE
update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ outputs:
   install_path:
     description: 'VS installation path'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
I have been using this repository for my own project's github workflow, but github currently gives node16 deprecation warnings.  I have forked this repo and made a new branch to use node20, and verified that modifying my workflow to point to my fork's node20 branch gets rid of the deprecation warnings.

I have marked this PR as a draft because I'm not sure whether it is better to keep both the `use-node20` branch and the `avoid-deprecation-warnings` (node16) branch, or to update the already-existing `avoid-deprecation-warnings` branch.

Also, if the preference is to keep both branches, can someone tell me how to modify this PR to create a branch in the `wxWidgets/gha-setup-vsdevenv` repo?  I only know how to make a PR that merges code into an existing branch.